### PR TITLE
Implement add menu for simplelayout types.

### DIFF
--- a/wcs/simplelayout/browser/configure.zcml
+++ b/wcs/simplelayout/browser/configure.zcml
@@ -66,4 +66,16 @@
         permission="zope2.DeleteObjects"
         />
 
+   <adapter for="wcs.simplelayout.contenttypes.behaviors.ISimplelayout
+                 wcs.simplelayout.interfaces.ISimplelayoutLayer"
+            name="plone.contentmenu.factories"
+            factory=".menu.SimplelayoutFactoriesSubMenuItem"
+            provides="plone.app.contentmenu.interfaces.IContentMenuItem" />
+
+    <browser:menu
+        id="plone_contentmenu_factory_simplelayout"
+        title="The 'add' menu - allows the user to add new content items in the context"
+        class=".menu.SimplelayoutFactoriesMenu"
+    />
+
 </configure>

--- a/wcs/simplelayout/browser/menu.py
+++ b/wcs/simplelayout/browser/menu.py
@@ -1,0 +1,39 @@
+from plone import api
+from plone.app.contentmenu.menu import FactoriesMenu
+from plone.app.contentmenu.menu import FactoriesSubMenuItem
+from wcs.simplelayout.contenttypes.behaviors import IBlockMarker
+
+
+class SimplelayoutFactoriesSubMenuItem(FactoriesSubMenuItem):
+    submenuId = "plone_contentmenu_factory_simplelayout"
+    
+    def _addableTypesInContext(self, addContext):
+        addable_ftis = super()._addableTypesInContext(addContext)
+        filtered = list(
+            filter(
+                lambda fti: IBlockMarker.__identifier__ not in fti.behaviors,
+                addable_ftis
+            )
+        )
+        return filtered
+
+
+class SimplelayoutFactoriesMenu(FactoriesMenu):
+    def getMenuItems(self, context, request):
+        result = super().getMenuItems(context, request)
+
+        def is_block_fti(menu_item):
+            if '++add++' not in menu_item.get('action', ''):
+                # Not a factory menu item
+                return False
+
+            ftis = api.portal.get_tool('portal_types')
+            fti = ftis.get(menu_item['id'], None)
+
+            if fti is None:
+                return False
+
+            return IBlockMarker.__identifier__ not in fti.behaviors
+
+        filtered_result = filter(lambda menu_item: is_block_fti(menu_item), result)
+        return filtered_result

--- a/wcs/simplelayout/profiles/default/types/NewsFolder.xml
+++ b/wcs/simplelayout/profiles/default/types/NewsFolder.xml
@@ -12,6 +12,7 @@
  <property name="filter_content_types">True</property>
  <property name="allowed_content_types">
   <element value="News"/>
+  <element value="MediaFolder"/>
   <element value="Block"/>
   <element value="VideoBlock"/>
   <element value="FileListingBlock"/>

--- a/wcs/simplelayout/tests/builders.py
+++ b/wcs/simplelayout/tests/builders.py
@@ -16,6 +16,20 @@ class MediaFolderBuilder(DexterityBuilder):
 builder_registry.register('mediafolder', MediaFolderBuilder)
 
 
+class NewsFolderBuilder(DexterityBuilder):
+    portal_type = 'NewsFolder'
+
+
+builder_registry.register('news folder', NewsFolderBuilder)
+
+
+class NewsBuilder(DexterityBuilder):
+    portal_type = 'News'
+
+
+builder_registry.register('news', NewsBuilder)
+
+
 class BlockBuilder(DexterityBuilder):
     portal_type = 'Block'
 

--- a/wcs/simplelayout/tests/test_add_menu.py
+++ b/wcs/simplelayout/tests/test_add_menu.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from wcs.simplelayout.tests import FunctionalTesting
+
+
+class TestSampleTypes(FunctionalTesting):
+    @browsing
+    def test_blocks_not_in_add_menu(self, browser):
+        page = create(Builder('content page').titled('A Page'))
+        browser.login().visit(page)
+        self.assertEquals(['Content Page', 'Media Folder', 'News Folder'],
+                          factoriesmenu.addable_types())
+
+        newsfolder = create(Builder('news folder').titled('A News Folder'))
+
+        browser.login().visit(newsfolder)
+        self.assertEquals(['Media Folder', 'News'],
+                          factoriesmenu.addable_types())

--- a/wcs/simplelayout/tests/test_contenttypes.py
+++ b/wcs/simplelayout/tests/test_contenttypes.py
@@ -23,8 +23,7 @@ class TestSampleTypes(FunctionalTesting):
     def test_add_default_block(self, browser):
         contentpage = create(Builder('content page').titled(u'A page'))
 
-        browser.login().visit(contentpage)
-        factoriesmenu.add('Block')
+        browser.login().open(contentpage, view='++add++Block')
         browser.fill({'Title': u'This is a Block',
                       'Text': u'<p>Some text</p>'})
         browser.find_button_by_label('Save').click()

--- a/wcs/simplelayout/tests/test_media_reference.py
+++ b/wcs/simplelayout/tests/test_media_reference.py
@@ -11,8 +11,7 @@ class TestMediaFolderReference(FunctionalTesting):
     def test_add_default_block(self, browser):
         contentpage = create(Builder('content page').titled(u'A page'))
         mediafolder = create(Builder('mediafolder').titled(u'A media folder'))
-        browser.login().visit(contentpage)
-        factoriesmenu.add('FileListingBlock')
+        browser.login().visit(contentpage, view='++add++FileListingBlock')
         browser.fill({'Title': u'This is a Block',
                       'Mediafolder reference': mediafolder})
         browser.find_button_by_label('Save').click()

--- a/wcs/simplelayout/tests/test_videoblock.py
+++ b/wcs/simplelayout/tests/test_videoblock.py
@@ -71,7 +71,7 @@ class TestVideoBlock(FunctionalTesting):
     @browsing
     def test_adding_youtube_videoblock(self, browser):
         browser.login().visit(self.page)
-        factoriesmenu.add('VideoBlock')
+        browser.visit(self.page, view='++add++VideoBlock')
         browser.fill(
             {
                 'Title': 'Youtube Video',
@@ -88,7 +88,7 @@ class TestVideoBlock(FunctionalTesting):
     @browsing
     def test_adding_vimeo_videoblock(self, browser):
         browser.login().visit(self.page)
-        factoriesmenu.add('VideoBlock')
+        browser.visit(self.page, view='++add++VideoBlock')
         browser.fill(
             {
                 'Title': 'Vimeo Video',
@@ -105,7 +105,7 @@ class TestVideoBlock(FunctionalTesting):
     @browsing
     def test_video_url_invariant(self, browser):
         browser.login().visit(self.page)
-        factoriesmenu.add('VideoBlock')
+        browser.visit(self.page, view='++add++VideoBlock')
         browser.fill({'Youtube, or Vimeo URL': 'https://example.com'})
         browser.find_button_by_label('Save').click()
 


### PR DESCRIPTION
The menu does not show simplelayout blocks.
They are only addable within the simplelayout vuejs app.