### PR TITLE
Add default sort_limit to newslistingblock serializer

### DIFF
--- a/wcs/simplelayout/restapi/serializer.py
+++ b/wcs/simplelayout/restapi/serializer.py
@@ -34,6 +34,7 @@ from wcs.simplelayout.contenttypes.behaviors import ISimplelayout
 from wcs.simplelayout.fields.table import ITableRichText
 from wcs.simplelayout.utils import add_layout_properties
 from wcs.simplelayout.utils import add_missing_blocks
+from wcs.simplelayout.utils import add_sort_limit_to_query
 from wcs.simplelayout.utils import convert_table_to_json
 from wcs.simplelayout.utils import list_blocks_from_page
 from zope.component import adapter
@@ -289,6 +290,11 @@ class NewsListingBlockSerializer(DefaultBlockSerializer):
             if original_b_size is None:
                 self.request.form['b_size'] = IBlockNewsOptions(self.context).quantity
             self.request['ACTUAL_URL'] = self.context.absolute_url()
+
+            try:
+                add_sort_limit_to_query(query)
+            except ValueError:
+                LOG.warn('Cannot set sort_limit')
 
             lazy_resultset = api.portal.get_tool('portal_catalog').searchResults(**query)
             search_result = getMultiAdapter(

--- a/wcs/simplelayout/utils.py
+++ b/wcs/simplelayout/utils.py
@@ -10,6 +10,7 @@ from plone.dexterity.interfaces import IDexterityFTI
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from wcs.simplelayout.contenttypes.behaviors import IBlockMarker
 from zope.component import getUtility
+from zope.globalrequest import getRequest
 import logging
 import os
 
@@ -208,3 +209,21 @@ def convert_table_to_json(table):
 
         result['rows'].append(row_data)
     return result
+
+
+def add_sort_limit_to_query(query):
+    request = getRequest()
+    b_start = int(request.form.get('b_start', '0'))
+    b_size = int(request.form.get('b_size', '0'))
+    if b_size == 0:
+        return
+    elif b_size < 0 or b_start < 0:
+        raise ValueError('Negative numbers are not supported')
+
+    page = int((b_start / b_size) + 1)
+
+    if b_start == 0:
+        query['sort_limit'] = b_size
+    else:
+        query['sort_limit'] = page * b_size
+


### PR DESCRIPTION
If there is a lot of news, this improves the performance significantly 